### PR TITLE
Fix docker PHP8 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - ALPINE_VERSION=3.16
-        - PHP_VERSION=php8
+        - PHP_VERSION=8.1.0
     volumes:
       - .:/data
       - ./docker/apache2.conf:/etc/apache2/sites-enabled/000-default.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,8 @@ RUN install-php-extensions \
     intl \
     pdo_mysql \
     soap \
+    sodium \
+    sockets \
     xsl \
     zip
 


### PR DESCRIPTION
- `php8-apache` cannot be found
- add required php extensions