### PR TITLE
Product reviews changes

### DIFF
--- a/common/Model/Api.php
+++ b/common/Model/Api.php
@@ -9,6 +9,7 @@ use Magento\Framework\Module\ModuleListInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\ResourceModel\Order\Item\Collection\Interceptor;
 use Psr\Log\LoggerInterface;
 use Valued\Magento2\Helper\General as GeneralHelper;
 use Valued\Magento2\Helper\Invitation as InvitationHelper;
@@ -161,7 +162,7 @@ class Api {
         $request['platform_version'] = $this->getPlatformVersion();
         $request['plugin_version'] = $this->getPluginVersion();
         $request['noremail'] = $config['noremail'];
-        $orderItems = $order->getItems();
+        $orderItems = $order->getItemsCollection([], true);
         $orderData = [
             'products' => $this->getProducts($orderItems, $config, $storeId)
         ];
@@ -181,13 +182,9 @@ class Api {
         return $this->postInvitation($request, $config);
     }
 
-    private function getProducts(array $orderItems, array $config, ?int $storeId): array {
-        if (empty($config['product_reviews'])) {
-            return [];
-        }
-
+    private function getProducts(Interceptor $orderItems, array $config, ?int $storeId): array {
         $products = [];
-        foreach ($orderItems as $item) {
+        foreach ($orderItems->getItems() as $item) {
             $id = $item->getProductId();
             try {
                 $product = $this->productRepository->getById($id, false, $storeId);

--- a/common/Model/Api.php
+++ b/common/Model/Api.php
@@ -186,7 +186,7 @@ class Api {
         try {
             return $this->getProducts($orderItems, $config, $storeId);
         } catch (\Exception $e) {
-            $this->logger->debug(sprintf('Error retrieving products: %s', $e->getMessage()));
+            $this->logger->debug(sprintf('Error retrieving products: %s: (%s) %s', get_class($e), $e->getCode(), $e->getMessage()));
             return [];
         }
     }


### PR DESCRIPTION
- Send products data with every invite - preparation for "freemium" product reviews
- `order-> getItems()` returns both the parent and the child item, this results in 2 product review requests in the review flow. Use `getItemsCollection` with `nonChildrenOnly` option.
